### PR TITLE
ISSUE-6  master fails build with tests 

### DIFF
--- a/src/test/java/com/fluenda/parcefone/parser/CEFParserTest.java
+++ b/src/test/java/com/fluenda/parcefone/parser/CEFParserTest.java
@@ -282,7 +282,7 @@ public class CEFParserTest {
 
     @Test
     public void testMissingHeaders() throws Exception {
-        String sample1 = "CEF:0||threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 ";
+        String sample1 = "CEF:0||threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1";
 
         CEFParser parser = new CEFParser();
 


### PR DESCRIPTION
There is an extra space trailing in the test with missing headers test line.
I have resolved it by removing the space from the tests.  You may want to think about trim() with fields like this.