### PR TITLE
Implemented MacAddress model to replace macnificent class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,15 +90,15 @@
             <version>3.0.0</version>
         </dependency>
         <dependency>
-            <groupId>com.martiansoftware</groupId>
-            <artifactId>macnificent</artifactId>
-            <version>0.2.0</version>
-            <scope>compile</scope>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.30</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -109,18 +109,16 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.3.6.Final</version>
+            <version>5.4.3.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.1-b12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <!-- used to get macnificent -->
-        <repository>
-            <id>martiansoftware</id>
-            <url>http://mvn.martiansoftware.com</url>
-        </repository>
-    </repositories>
 
     <build>
         <resources>
@@ -188,6 +186,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <fork>true</fork>
                     <optimize>true</optimize>
@@ -229,7 +228,7 @@
                     <plugin>
                         <groupId>org.apache.rat</groupId>
                         <artifactId>apache-rat-plugin</artifactId>
-                        <version>0.12</version>
+                        <version>0.13</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/src/main/java/com/fluenda/parcefone/event/CefRev23.java
+++ b/src/main/java/com/fluenda/parcefone/event/CefRev23.java
@@ -16,9 +16,6 @@
  */
 package com.fluenda.parcefone.event;
 
-import com.martiansoftware.macnificent.MacAddress;
-
-
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;

--- a/src/main/java/com/fluenda/parcefone/event/MacAddress.java
+++ b/src/main/java/com/fluenda/parcefone/event/MacAddress.java
@@ -1,0 +1,171 @@
+/*
+ * (C) Copyright 2021 Fluenda.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.fluenda.parcefone.event;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Media Access Control Address based on com.martiansoftware.macnificent.MacAddress
+ */
+public class MacAddress implements Comparable<MacAddress> {
+    private static final int ADDRESS_LENGTH = 6;
+
+    private static final byte MUTLTICAST_FLAG = 0x01;
+
+    private static final byte LOCAL_FLAG = 0x02;
+
+    private static final char STANDARD_SEPARATOR = ':';
+
+    private static final Pattern ADDRESS_PATTERN;
+
+    static {
+        final StringBuilder patternBuilder = new StringBuilder("^\\s*");
+        for (int i = 1; i <= ADDRESS_LENGTH; i++) {
+            patternBuilder.append("([0-9a-fA-F]{2})");
+            if (i != ADDRESS_LENGTH) {
+                patternBuilder.append("(?:[\\s-:._]?)"); // Ignore element separators
+            }
+        }
+        patternBuilder.append("\\s*$");
+        ADDRESS_PATTERN = Pattern.compile(patternBuilder.toString());
+    }
+
+    private final byte[] address;
+
+    /**
+     * MAC Address constructor capable of parsing hexadecimal encoded values with or without separators
+     *
+     * @param macAddress Hexadecimal encoded address
+     */
+    public MacAddress(final String macAddress) {
+        address = parseMacAddress(macAddress);
+    }
+
+    /**
+     * Get Byte Array of Address using Arrays.copyOf()
+     *
+     * @return Byte Array of Address
+     */
+    public byte[] getBytes() {
+        return Arrays.copyOf(address, ADDRESS_LENGTH);
+    }
+
+    /**
+     * Is Multicast Address
+     *
+     * @return Multicast Address status
+     */
+    public boolean isMulticast() {
+        return (address[0] & MUTLTICAST_FLAG) == MUTLTICAST_FLAG;
+    }
+
+    /**
+     * Is Local Address
+     *
+     * @return Local Address status
+     */
+    public boolean isLocal() {
+        return (address[0] & LOCAL_FLAG) == LOCAL_FLAG;
+    }
+
+    /**
+     * Format Address using lowercase hexadecimal encoding with standard separator such as 00:00:00:00:00:00
+     *
+     * @return Hexadecimal encoded address with standard separator
+     */
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < address.length; i++) {
+            if (i != 0) {
+                builder.append(STANDARD_SEPARATOR);
+            }
+            builder.append(String.format("%02x", address[i]));
+
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Equals comparison based on address byte array
+     *
+     * @param object Object for comparison
+     * @return Equals status
+     */
+    @Override
+    public boolean equals(final Object object) {
+        boolean equals = false;
+
+        if (object instanceof MacAddress) {
+            final MacAddress macAddress = (MacAddress) object;
+            equals = Arrays.equals(address, macAddress.address);
+        }
+
+        return equals;
+    }
+
+    /**
+     * Hash code based on Arrays.hashCode() of address byte array
+     *
+     * @return Hash code
+     */
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(address);
+    }
+
+    /**
+     * Compare to other MAC Address
+     *
+     * @param macAddress MAC Address for comparison
+     * @return Comparison is 0 when equivalent otherwise first difference in address byte values
+     */
+    @Override
+    public int compareTo(final MacAddress macAddress) {
+        int comparison = 0;
+
+        for (int i = 0; i < ADDRESS_LENGTH; i++) {
+            comparison = address[i] - macAddress.address[i];
+            if (comparison != 0) {
+                break;
+            }
+        }
+
+        return comparison;
+    }
+
+    private byte[] parseMacAddress(final String macAddress) {
+        Objects.requireNonNull(macAddress, "Address required");
+
+        final Matcher matcher = ADDRESS_PATTERN.matcher(macAddress);
+        if (matcher.matches()) {
+            final byte[] parsedAddress = new byte[ADDRESS_LENGTH];
+            for (int group = 1; group <= ADDRESS_LENGTH; group++) {
+                final String matchedGroup = matcher.group(group);
+                final int parsedGroup = Integer.parseInt(matchedGroup, 16);
+                final int index = group - 1;
+                parsedAddress[index] = (byte) parsedGroup;
+            }
+            return parsedAddress;
+        } else {
+            throw new IllegalArgumentException(String.format("Address not valid [%s]", macAddress));
+        }
+    }
+}

--- a/src/test/java/com/fluenda/parcefone/event/MacAddressTest.java
+++ b/src/test/java/com/fluenda/parcefone/event/MacAddressTest.java
@@ -1,0 +1,138 @@
+/*
+ * (C) Copyright 2021 Fluenda.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.fluenda.parcefone.event;
+
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class MacAddressTest {
+
+    private static final String NORMALIZED_ADDRESS = "00:ff:00:ff:00:ff";
+
+    private static final String HYPHEN_SEPARATOR = "00-ff-00-ff-00-ff";
+
+    private static final String UNDERSCORE_SEPARATOR = "00_ff_00_ff_00_ff";
+
+    private static final String SPACE_SEPARATOR = "00 ff 00 ff 00 ff";
+
+    private static final String PERIOD_SEPARATOR = "00.ff.00.ff.00.ff";
+
+    private static final String NO_SEPARATOR = "00ff00ff00ff";
+
+    private static final String LOCAL_ADDRESS = "ff:ff:ff:ff:ff:ff";
+
+    private static final String MULTICAST_ADDRESS = "01:80:c2:00:00:00";
+
+    private static final String INVALID_LENGTH = "00:ff:00:ff:00";
+
+    @Test
+    public void testAddressNormalizedSeparator() {
+        final MacAddress macAddress = new MacAddress(NORMALIZED_ADDRESS);
+        assertEquals(NORMALIZED_ADDRESS, macAddress.toString());
+    }
+
+    @Test
+    public void testAddressHyphenSeparator() {
+        final MacAddress macAddress = new MacAddress(HYPHEN_SEPARATOR);
+        assertEquals(NORMALIZED_ADDRESS, macAddress.toString());
+    }
+
+    @Test
+    public void testAddressUnderscoreSeparator() {
+        final MacAddress macAddress = new MacAddress(UNDERSCORE_SEPARATOR);
+        assertEquals(NORMALIZED_ADDRESS, macAddress.toString());
+    }
+
+    @Test
+    public void testAddressSpaceSeparator() {
+        final MacAddress macAddress = new MacAddress(SPACE_SEPARATOR);
+        assertEquals(NORMALIZED_ADDRESS, macAddress.toString());
+    }
+
+    @Test
+    public void testAddressPeriodSeparator() {
+        final MacAddress macAddress = new MacAddress(PERIOD_SEPARATOR);
+        assertEquals(NORMALIZED_ADDRESS, macAddress.toString());
+    }
+
+    @Test
+    public void testAddressNoSeparator() {
+        final MacAddress macAddress = new MacAddress(NO_SEPARATOR);
+        assertEquals(NORMALIZED_ADDRESS, macAddress.toString());
+    }
+
+    @Test
+    public void testAddressInvalidLength() {
+        assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
+            @Override
+            public void run() {
+                new MacAddress(INVALID_LENGTH);
+            }
+        });
+    }
+
+    @Test
+    public void testAddressLocal() {
+        final MacAddress macAddress = new MacAddress(LOCAL_ADDRESS);
+        assertTrue(macAddress.isLocal());
+    }
+
+    @Test
+    public void testAddressMulticast() {
+        final MacAddress macAddress = new MacAddress(MULTICAST_ADDRESS);
+        assertTrue(macAddress.isMulticast());
+    }
+
+    @Test
+    public void testAddressMulticastNotLocal() {
+        final MacAddress macAddress = new MacAddress(MULTICAST_ADDRESS);
+        assertFalse(macAddress.equals(new MacAddress(LOCAL_ADDRESS)));
+    }
+
+    @Test
+    public void testAddressGetBytes() {
+        final MacAddress macAddress = new MacAddress(MULTICAST_ADDRESS);
+        assertNotNull(macAddress.getBytes());
+    }
+
+    @Test
+    public void testAddressHashCode() {
+        final MacAddress macAddress = new MacAddress(MULTICAST_ADDRESS);
+        assertNotEquals(0, macAddress.hashCode());
+    }
+
+    @Test
+    public void testAddressCompareToEqual() {
+        final MacAddress macAddress = new MacAddress(MULTICAST_ADDRESS);
+        final int comparison = macAddress.compareTo(macAddress);
+        assertEquals(0, comparison);
+    }
+
+    @Test
+    public void testAddressCompareToNotEqual() {
+        final MacAddress macAddress = new MacAddress(MULTICAST_ADDRESS);
+        final int comparison = macAddress.compareTo(new MacAddress(LOCAL_ADDRESS));
+        assertNotEquals(0, comparison);
+    }
+}

--- a/src/test/java/com/fluenda/parcefone/parser/CEFParserTest.java
+++ b/src/test/java/com/fluenda/parcefone/parser/CEFParserTest.java
@@ -17,7 +17,7 @@
 package com.fluenda.parcefone.parser;
 
 import com.fluenda.parcefone.event.CommonEvent;
-import com.martiansoftware.macnificent.MacAddress;
+import com.fluenda.parcefone.event.MacAddress;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
Refactored to replace dependency on macnificent.MacAddress to address issue #16 with builds failing on Apache Maven 3.8.1.

- Followed implementation from com.martiansoftware.macnificent.MacAddress
- Removed dependency on com.martiansoftware:macnificent
- Changed slf4j-log4j12 to test dependency and added slf4j-api dependency
- Upgraded hibernate-validator to 5.4.3.Final and added required org.glassfish:javax.el dependency for testing