### PR TITLE
Ignore empty extensions instead of failing

### DIFF
--- a/src/main/java/com/fluenda/parcefone/event/CefRev23.java
+++ b/src/main/java/com/fluenda/parcefone/event/CefRev23.java
@@ -581,6 +581,12 @@ public class CefRev23 extends CommonEvent {
             try {
                 Field field = objClass.getDeclaredField(key);
                 String value = extensions.get(key);
+
+                // If the value is null/empty, let's just move on to the next one
+                if(value == null || value.isEmpty()) {
+                    continue;
+                }
+
                 // Treat each Classes in a particular fashion
 
                 // Inet, Inet4 and Inet6 address
@@ -649,10 +655,10 @@ public class CefRev23 extends CommonEvent {
 
                 // The rest (to be removed)
                 } else {
-                    field.set(this, value );
+                    field.set(this, value);
                 }
 
-                // Add the key to the populate keys listt
+                // Add the key to the populate keys list
                 populatedExtensions.add(key);
             } catch (NoSuchFieldException e) {
                 customExtensions.put(key, extensions.get(key));

--- a/src/main/java/com/fluenda/parcefone/event/CefRev23.java
+++ b/src/main/java/com/fluenda/parcefone/event/CefRev23.java
@@ -100,42 +100,42 @@ public class CefRev23 extends CommonEvent {
     @Size(max = 1023)
     private String c6a4Label;
 
-    private float cfp1;
+    private Float cfp1;
 
     @Size(max = 1023)
     private String cfp1Label;
 
-    private float cfp2;
+    private Float cfp2;
 
     @Size(max = 1023)
     private String cfp2Label;
 
-    private float cfp3;
+    private Float cfp3;
 
     @Size(max = 1023)
     private String cfp3Label;
 
-    private float cfp4;
+    private Float cfp4;
 
     @Size(max = 1023)
     private String cfp4Label;
 
-    private long cn1;
+    private Long cn1;
 
     @Size(max = 1023)
     private String cn1Label;
 
-    private long cn2;
+    private Long cn2;
 
     @Size(max = 1023)
     private String cn2Label;
 
-    private long cn3;
+    private Long cn3;
 
     @Size(max = 1023)
     private String cn3Label;
 
-    private long cnt;
+    private Long cnt;
 
     @Size(max = 4000)
     private String cs1;
@@ -181,7 +181,7 @@ public class CefRev23 extends CommonEvent {
 
     private Inet4Address destinationTranslatedAddress;
 
-    private int destinationTranslatedPort;
+    private Integer destinationTranslatedPort;
 
     private Date deviceCustomDate1;
 
@@ -197,7 +197,7 @@ public class CefRev23 extends CommonEvent {
     // 0 = inbound 1 is outbound
     @Min(0)
     @Max(1)
-    private int deviceDirection;
+    private Integer deviceDirection;
 
     @Size(max = 255)
     private String deviceDnsDomain;
@@ -233,7 +233,7 @@ public class CefRev23 extends CommonEvent {
     @Size(max = 255)
     private String dntdom;
 
-    private int dpid;
+    private Integer dpid;
 
     @Size(max = 1023)
     private String dpriv;
@@ -242,7 +242,7 @@ public class CefRev23 extends CommonEvent {
     private String dproc;
 
     @Max(65535)
-    private int dpt;
+    private Integer dpt;
 
     private Inet4Address dst;
 
@@ -262,7 +262,7 @@ public class CefRev23 extends CommonEvent {
 
     private MacAddress dvcmac;
 
-    private int dvcpid;
+    private Integer dvcpid;
 
     private Date end;
 
@@ -293,12 +293,12 @@ public class CefRev23 extends CommonEvent {
     @Size(max = 128)
     private String flexDate1Label;
 
-    private long flexNumber1;
+    private Long flexNumber1;
 
     @Size(max = 128)
     private String flexNumber1Label;
 
-    private long flexNumber2;
+    private Long flexNumber2;
 
     @Size(max = 128)
     private String flexNumber2Label;
@@ -318,9 +318,9 @@ public class CefRev23 extends CommonEvent {
     @Size(max = 1023)
     private String fname;
 
-    private int fsize;
+    private Integer fsize;
 
-    private int in;
+    private Integer in;
 
     @Size(max = 1023)
     private String msg;
@@ -344,12 +344,12 @@ public class CefRev23 extends CommonEvent {
     @Size(max = 1023)
     private String oldFilePermission;
 
-    private int oldFileSize;
+    private Integer oldFileSize;
 
     @Size(max = 1023)
     private String oldFileType;
 
-    private int out;
+    private Integer out;
 
     @Size(max = 63)
     private String outcome;
@@ -394,9 +394,9 @@ public class CefRev23 extends CommonEvent {
 
     private Inet4Address sourceTranslatedAddress;
 
-    private int sourceTranslatedPort;
+    private Integer sourceTranslatedPort;
 
-    private int spid;
+    private Integer spid;
 
     @Size(max = 1023)
     private String spriv;
@@ -405,7 +405,7 @@ public class CefRev23 extends CommonEvent {
     private String sproc;
 
     @Max(65535)
-    private int spt;
+    private Integer spt;
 
     private Inet4Address src;
 
@@ -419,7 +419,7 @@ public class CefRev23 extends CommonEvent {
 
     @Min(0)
     @Max(3)
-    private int type;
+    private Integer type;
 
     @Size(max = 255)
     private String agentDnsDomain;
@@ -495,18 +495,18 @@ public class CefRev23 extends CommonEvent {
     @Size(max = 2048)
     private String deviceZoneURI;
 
-    private double dlat;
+    private Double dlat;
 
-    private double dlong;
+    private Double dlong;
 
-    private long eventId;
+    private Long eventId;
 
     @Size(max = 4000)
     private String rawEvent;
 
-    private double slat;
+    private Double slat;
 
-    private double slong;
+    private Double slong;
 
     @Size(max = 200)
     private String sourceTranslatedZoneExternalID;
@@ -571,87 +571,118 @@ public class CefRev23 extends CommonEvent {
         return headers;
     }
 
-
     /**
      * @param extensions A map containing the keys and values of extensions of CEF event
      * @throws CEFHandlingException when it has issues populating the extensions
      */
     public void setExtension(Map<String, String> extensions) throws CEFHandlingException {
+        setExtension(extensions, false);
+    }
+
+    /**
+     * @param extensions A map containing the keys and values of extensions of CEF event
+     * @param allowNulls If true, extensions with an empty value will be seen as null. If false, parsing may fail depending on extension types
+     * @throws CEFHandlingException when it has issues populating the extensions
+     */
+    public void setExtension(Map<String, String> extensions, final boolean allowNulls) throws CEFHandlingException {
         for (String key : extensions.keySet()) {
             try {
                 Field field = objClass.getDeclaredField(key);
                 String value = extensions.get(key);
 
-                // If the value is null/empty, let's just move on to the next one
-                if(value == null || value.isEmpty()) {
-                    continue;
-                }
-
                 // Treat each Classes in a particular fashion
 
                 // Inet, Inet4 and Inet6 address
                 if (field.getType().equals(InetAddress.class) || field.getType().equals(Inet4Address.class) || field.getType().equals(Inet6Address.class)) {
-                    try {
-                        InetAddress inetAddress = InetAddress.getByName((String) value);
-                        field.set(this, inetAddress);
-                    } catch (UnknownHostException e) {
-                        throw new CEFHandlingException("Error setting value to field " + key, e);
+                    if(allowNulls && (value == null || value.isEmpty())) {
+                        field.set(this, null);
+                    } else {
+                        try {
+                            InetAddress inetAddress = InetAddress.getByName((String) value);
+                            field.set(this, inetAddress);
+                        } catch (UnknownHostException e) {
+                            throw new CEFHandlingException("Error setting value to field " + key, e);
+                        }
                     }
 
                 // Date (timestamps) - Note we force a particular date format (set as private dateFormat above
                 } else if (field.getType().equals(Date.class)) {
-                    try {
-                        // Use a ": "to match epoch vs. Dateformat
-                        if (!value.toString().contains(":")) {
-                            // This is epoch
-                            field.set(this, new Date(Long.valueOf(value)));
-                        } else {
-                            // This is one of the remaining 8 possible values, regex it out...
-                            Matcher matcher = timeRegex.matcher(value);
+                    if(allowNulls && (value == null || value.isEmpty())) {
+                        field.set(this, null);
+                    } else {
+                        try {
+                            // Use a ": "to match epoch vs. Dateformat
+                            if (!value.toString().contains(":")) {
+                                // This is epoch
+                                field.set(this, new Date(Long.valueOf(value)));
+                            } else {
+                                // This is one of the remaining 8 possible values, regex it out...
+                                Matcher matcher = timeRegex.matcher(value);
 
-                            if (matcher.matches()) {
-                                String year = matcher.group("YEAR") == null ? String.valueOf(Calendar.getInstance().get(Calendar.YEAR)) : matcher.group("YEAR") ;
-                                String milli = matcher.group("MILLI") == null ? "000" : matcher.group("MILLI");
+                                if (matcher.matches()) {
+                                    String year = matcher.group("YEAR") == null ? String.valueOf(Calendar.getInstance().get(Calendar.YEAR)) : matcher.group("YEAR") ;
+                                    String milli = matcher.group("MILLI") == null ? "000" : matcher.group("MILLI");
 
-                                String regexDate =
-                                        year + "-" +
-                                        matcher.group("MONTH") + "-" +
-                                        matcher.group("DAY") + " " +
-                                        matcher.group("HOUR") + ":" +
-                                        matcher.group("MINUTE") + ":" +
-                                        matcher.group("SECOND") + "." +
-                                        milli;
-                                if (matcher.group("TZ") == null ) {
-                                    field.set(this, dateFormat(false).parse(regexDate));
-                                } else {
-                                    regexDate = regexDate + " " + matcher.group("TZ");
-                                    field.set(this, dateFormat(true).parse(regexDate));
+                                    String regexDate =
+                                            year + "-" +
+                                            matcher.group("MONTH") + "-" +
+                                            matcher.group("DAY") + " " +
+                                            matcher.group("HOUR") + ":" +
+                                            matcher.group("MINUTE") + ":" +
+                                            matcher.group("SECOND") + "." +
+                                            milli;
+                                    if (matcher.group("TZ") == null ) {
+                                        field.set(this, dateFormat(false).parse(regexDate));
+                                    } else {
+                                        regexDate = regexDate + " " + matcher.group("TZ");
+                                        field.set(this, dateFormat(true).parse(regexDate));
+                                    }
                                 }
                             }
+                        } catch (ParseException|NumberFormatException e) {
+                            throw new CEFHandlingException("Error setting value to field " + key, e);
                         }
-                    } catch (ParseException|NumberFormatException e) {
-                        throw new CEFHandlingException("Error setting value to field " + key, e);
                     }
 
                 // Mac Addresses
                 } else if (field.getType().equals(MacAddress.class)) {
-                    field.set(this, new MacAddress(value));
+                    if(allowNulls && (value == null || value.isEmpty())) {
+                        field.set(this, null);
+                    } else {
+                        field.set(this, new MacAddress(value));
+                    }
 
                 // Integers
-                } else if (field.getType().equals(int.class)) {
-                    field.set(this, Integer.valueOf(value));
+                } else if (field.getType().equals(Integer.class)) {
+                    if(allowNulls && (value == null || value.isEmpty())) {
+                        field.set(this, null);
+                    } else {
+                        field.set(this, Integer.valueOf(value));
+                    }
 
                 // Longs
-                } else if (field.getType().equals(long.class)){
-                    field.set(this, Long.valueOf(value));
+                } else if (field.getType().equals(Long.class)){
+                    if(allowNulls && (value == null || value.isEmpty())) {
+                        field.set(this, null);
+                    } else {
+                        field.set(this, Long.valueOf(value));
+                    }
 
                 // Doubles
-                } else if (field.getType().equals(double.class)) {
-                    field.set(this, Double.valueOf(value));
+                } else if (field.getType().equals(Double.class)) {
+                    if(allowNulls && (value == null || value.isEmpty())) {
+                        field.set(this, null);
+                    } else {
+                        field.set(this, Double.valueOf(value));
+                    }
 
                 // Floats
-                } else if (field.getType().equals(float.class)) {
-                    field.set(this, Float.valueOf(value));
+                } else if (field.getType().equals(Float.class)) {
+                    if(allowNulls && (value == null || value.isEmpty())) {
+                        field.set(this, null);
+                    } else {
+                        field.set(this, Float.valueOf(value));
+                    }
 
                 // The rest (to be removed)
                 } else {
@@ -721,7 +752,5 @@ public class CefRev23 extends CommonEvent {
             return new SimpleDateFormat("yyyy-MMM-dd HH:mm:ss.SSS", this.dateLocale);
         }
     }
-
-
 
 }

--- a/src/main/java/com/fluenda/parcefone/event/CommonEvent.java
+++ b/src/main/java/com/fluenda/parcefone/event/CommonEvent.java
@@ -38,6 +38,13 @@ public abstract class CommonEvent {
     public abstract void setExtension(Map<String, String> extensions) throws CEFHandlingException;
 
     /**
+     * @param extensions A map containing the keys and values of extensions of CEF event
+     * @param allowNulls If true, extensions with an empty value will be seen as null. If false, parsing may fail depending on extension types
+     * @throws CEFHandlingException when it has issues populating the extensions
+     */
+    public abstract void setExtension(Map<String, String> extensions, final boolean allowNulls) throws CEFHandlingException;
+
+    /**
      * @return A map containing the keys and values of headers
      * @throws CEFHandlingException when it has issues reading the headers of CEF event
      */

--- a/src/main/java/com/fluenda/parcefone/parser/CEFParser.java
+++ b/src/main/java/com/fluenda/parcefone/parser/CEFParser.java
@@ -96,6 +96,19 @@ public class CEFParser {
         return this.parse(cefString, validate, locale);
     }
 
+    /**
+     * @return CommonEvent
+     * @param cefByteArray byte [] containing the CEF message to be parsed - Array will be converted String using UTF-8
+     * @param validate Boolean if parser should validate values beyond type compatibility (e.g. Values within acceptable lengths, value lists, etc)
+     * @param allowNulls If true, extensions with an empty value will be seen as null. If false, parsing may fail depending on extension types
+     * @param locale The locale to be used when parsing dates (so that parser can handle both jul (en_US) and juil.(fr_FR)
+     */
+    public CommonEvent parse(byte [] cefByteArray, boolean validate, final boolean allowNulls, Locale locale)  {
+        String cefString;
+        cefString = new String(cefByteArray, Charset.forName("UTF-8"));
+        return this.parse(cefString, validate, allowNulls, locale);
+    }
+
 
     /**
      * <p>
@@ -131,6 +144,19 @@ public class CEFParser {
      * @return CommonEvent
      */
     public CommonEvent parse(String cefString, final boolean validate, Locale locale)  {
+        return this.parse(cefString, validate, false, locale);
+    }
+
+    /**
+     * Converts a CEF formatted String into a {@link CommonEvent} object with exposed control over validation and the
+     * {@link Locale} used to parse fields containing {@link Date Dates}
+     * @param cefString String containing the CEF message to be parsed
+     * @param validate Boolean if parser should validate values beyond type compatibility (e.g. Values within acceptable lengths, value lists, etc)
+     * @param allowNulls If true, extensions with an empty value will be seen as null. If false, parsing may fail depending on extension types
+     * @param locale The locale to be used when parsing dates (so that parser can handle both jul (en_US) and juil.(fr_FR)
+     * @return CommonEvent
+     */
+    public CommonEvent parse(String cefString, final boolean validate, final boolean allowNulls, Locale locale)  {
 
         int cefHeaderSize = 7;
         CommonEvent cefEvent = new CefRev23(locale);
@@ -206,7 +232,7 @@ public class CEFParser {
 
         try {
             cefEvent.setHeader(headers);
-            cefEvent.setExtension(extensions);
+            cefEvent.setExtension(extensions, allowNulls);
 
         } catch (CEFHandlingException e) {
             logger.error(e.toString());

--- a/src/test/java/com/fluenda/parcefone/parser/CEFParserTest.java
+++ b/src/test/java/com/fluenda/parcefone/parser/CEFParserTest.java
@@ -18,6 +18,8 @@ package com.fluenda.parcefone.parser;
 
 import com.fluenda.parcefone.event.CommonEvent;
 import com.fluenda.parcefone.event.MacAddress;
+import com.fluenda.parcefone.parser.CEFParser;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -128,6 +130,20 @@ public class CEFParserTest {
         Assert.assertTrue(parser.parse(sample1).getHeader().containsKey("deviceVendor"));
         Assert.assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1).getExtension(true).get("dvc"));
         Assert.assertNull(parser.parse(sample1).getExtension(true).get("act"));
+    }
+
+    @Test
+    public void validMessageWithEmptyExtensions() throws Exception {
+        String sample1 = "CEF:0|FireEye|CMS|7.2.1.244420|DM|domain-match|1|rt=Feb 09 2015 00:27:43 UTC cn3Label= cn3= cn2Label=sid cn2=80494706 shost=dev001srv02.example.com proto=udp cs5Label=cncHost cs5=mfdclk001.org dvchost=DEVFEYE1 spt=61395 dvc= smac= cn1Label=vlan cn1=0 externalId=851777 cs4Label=link cs4=https://DEVCMS01.example.com/event_stream/events_for_bot?ev_id\\=851777 dmac=00:1d:a2:af:32:a1 cs1Label=sname cs1=Trojan.Generic.DNS ";
+        CEFParser parser = new CEFParser();
+
+        // Test sample
+        Assert.assertNotNull(parser.parse(sample1));
+        Assert.assertTrue(parser.parse(sample1).getHeader().containsKey("deviceVendor"));
+        Assert.assertNull(parser.parse(sample1).getExtension(true).get("act"));
+        Assert.assertNull(parser.parse(sample1).getExtension(true).get("cn3"));
+        Assert.assertNull(parser.parse(sample1).getExtension(true).get("dvc"));
+        Assert.assertNull(parser.parse(sample1).getExtension(true).get("smac"));
     }
 
     @Test

--- a/src/test/java/com/fluenda/parcefone/parser/CEFParserTest.java
+++ b/src/test/java/com/fluenda/parcefone/parser/CEFParserTest.java
@@ -134,16 +134,20 @@ public class CEFParserTest {
 
     @Test
     public void validMessageWithEmptyExtensions() throws Exception {
-        String sample1 = "CEF:0|FireEye|CMS|7.2.1.244420|DM|domain-match|1|rt=Feb 09 2015 00:27:43 UTC cn3Label= cn3= cn2Label=sid cn2=80494706 shost=dev001srv02.example.com proto=udp cs5Label=cncHost cs5=mfdclk001.org dvchost=DEVFEYE1 spt=61395 dvc= smac= cn1Label=vlan cn1=0 externalId=851777 cs4Label=link cs4=https://DEVCMS01.example.com/event_stream/events_for_bot?ev_id\\=851777 dmac=00:1d:a2:af:32:a1 cs1Label=sname cs1=Trojan.Generic.DNS ";
+        String sample1 = "CEF:0|FireEye|CMS|7.2.1.244420|DM|domain-match|1|rt= cn3Label= cn3= cn2Label= cn2= shost= proto= cs5Label= cs5= dvchost= spt= dvc= smac= cn1Label= cn1= externalId= cs4Label= cs4= dmac= cs1Label= cs1=";
         CEFParser parser = new CEFParser();
 
+        // validation should be disabled if we allow for null values
+        // if not disabled, the parsing would be successful but the validation is likely to fail
+        CommonEvent result = parser.parse(sample1, false, true, Locale.ENGLISH);
+
         // Test sample
-        Assert.assertNotNull(parser.parse(sample1));
-        Assert.assertTrue(parser.parse(sample1).getHeader().containsKey("deviceVendor"));
-        Assert.assertNull(parser.parse(sample1).getExtension(true).get("act"));
-        Assert.assertNull(parser.parse(sample1).getExtension(true).get("cn3"));
-        Assert.assertNull(parser.parse(sample1).getExtension(true).get("dvc"));
-        Assert.assertNull(parser.parse(sample1).getExtension(true).get("smac"));
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.getHeader().containsKey("deviceVendor"));
+        Assert.assertFalse(result.getExtension(true).containsKey("act"));
+        Assert.assertTrue(result.getExtension(true).containsKey("cn3") && result.getExtension(true).get("cn3") == null);
+        Assert.assertTrue(result.getExtension(true).containsKey("dvc") && result.getExtension(true).get("dvc") == null);
+        Assert.assertTrue(result.getExtension(true).containsKey("smac") && result.getExtension(true).get("smac") == null);
     }
 
     @Test


### PR DESCRIPTION
I have a system (Pulse Secure) generating logs that may contain empty extensions. This would generate errors such as 

````
Exception java.lang.NumberFormatException: For input string: ""
````

This pull request changes the parsing so that empty extensions are just skipped. If we want to have this done according to a parameter (similar to the ``validate`` option), let me know.