### PR TITLE
Upgrade Dependencies for Jakarta EE 10

### DIFF
--- a/.github/workflows/mavenreleasedeploy.yml
+++ b/.github/workflows/mavenreleasedeploy.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: '11'
+          distribution: 'zulu'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/mavensnapshotdeploy.yml
+++ b/.github/workflows/mavensnapshotdeploy.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: '11'
+          distribution: 'zulu'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/mavenverify.yml
+++ b/.github/workflows/mavenverify.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: '11'
+          distribution: 'zulu'
       - name: verify with Maven
         run: mvn -Pcontrib-check --batch-mode --update-snapshots verify

--- a/pom.xml
+++ b/pom.xml
@@ -78,42 +78,43 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>1.1.0.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <version>3.0.0</version>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>2.0.10</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.30</version>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.4.3.Final</version>
+            <version>8.0.1.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
-            <version>3.0.1-b12</version>
+            <artifactId>jakarta.el</artifactId>
+            <version>5.0.0-M1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -134,12 +135,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.3.2</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.1.2</version>
+                    <version>3.3.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -147,13 +148,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.6.3</version>
                 <configuration>
-                    <aggregate>true</aggregate>
                     <show>public</show>
                     <nohelp>true</nohelp>
                     <header>${project.name}, ${project.version}</header>
-                    <footer>${project.name}, ${project.version}</footer>
                     <doctitle>${project.name}, ${project.version}</doctitle>
                     <links>
                         <link>http://static.springsource.org/spring/docs/3.0.x/javadoc-api/</link>
@@ -184,20 +183,20 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.12.1</version>
                 <configuration>
                     <fork>true</fork>
-                    <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>11</source>
+                    <target>11</target>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.3.1</version>
                 <configuration>
                     <violationSeverity>warning</violationSeverity>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -226,7 +225,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -254,7 +253,7 @@
                     <plugin>
                         <groupId>org.apache.rat</groupId>
                         <artifactId>apache-rat-plugin</artifactId>
-                        <version>0.13</version>
+                        <version>0.15</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/src/main/java/com/fluenda/parcefone/event/CEFHandlingException.java
+++ b/src/main/java/com/fluenda/parcefone/event/CEFHandlingException.java
@@ -16,13 +16,32 @@
  */
 package com.fluenda.parcefone.event;
 
+/**
+ * Common Event Format Handling Exception thrown on parsing failures
+ */
 public class CEFHandlingException extends Exception {
+    /**
+     * Default constructor with no arguments
+     */
     public CEFHandlingException() {
 
     }
+
+    /**
+     * Standard constructor with required message
+     *
+     * @param message Message describing failure
+     */
     public CEFHandlingException(String message) {
         super(message);
     }
+
+    /**
+     * Standard constructor with required message and cause
+     *
+     * @param message Message describing failure
+     * @param cause Throwable cause of parsing failure
+     */
     public CEFHandlingException(String message, Throwable cause) {
         super(message,cause);
     }

--- a/src/main/java/com/fluenda/parcefone/event/CefRev23.java
+++ b/src/main/java/com/fluenda/parcefone/event/CefRev23.java
@@ -16,10 +16,10 @@
  */
 package com.fluenda.parcefone.event;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import java.lang.reflect.Field;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -522,12 +522,19 @@ public class CefRev23 extends CommonEvent {
 
     private Locale dateLocale;
 
-
+    /**
+     * Standard constructor with locale for date objects
+     *
+     * @param locale Locale for date objects
+     */
     public CefRev23(Locale locale) {
         super();
         this.dateLocale = locale;
     }
 
+    /**
+     * Default constructor with date locale set to English
+     */
     public CefRev23() {
         super();
 

--- a/src/main/java/com/fluenda/parcefone/event/CommonEvent.java
+++ b/src/main/java/com/fluenda/parcefone/event/CommonEvent.java
@@ -19,25 +19,36 @@ package com.fluenda.parcefone.event;
 import java.util.Map;
 
 /**
- *  Implements a <i>struct like</i> class that holds headers and extension fields defined in the Common Event Format
- *  maintained by HP Enterprise and used by a number of cyber security solutions.
+ * Implements a <i>struct like</i> class that holds headers and extension fields defined in the Common Event Format
+ * maintained by HP Enterprise and used by a number of cyber security solutions.
  */
 public abstract class CommonEvent {
+    /**
+     * Default constructor for Common Events
+     */
+    public CommonEvent() {
+
+    }
 
     /**
+     * Set headers using named key to object value
+     *
      * @param headers A map containing the  keys and values of headers of CEF event
      * @throws CEFHandlingException when it has issues writing the values of the headers
-     *
      */
     public abstract void setHeader(Map<String, Object> headers) throws CEFHandlingException;
 
     /**
+     * Set extensions using named key to object value
+     *
      * @param extensions A map containing the keys and values of extensions of CEF event
      * @throws CEFHandlingException when it has issues populating the extensions
      */
     public abstract void setExtension(Map<String, String> extensions) throws CEFHandlingException;
 
     /**
+     * Set extensions using named key to object value with specified handling for null values
+     *
      * @param extensions A map containing the keys and values of extensions of CEF event
      * @param allowNulls If true, extensions with an empty value will be seen as null. If false, parsing may fail depending on extension types
      * @throws CEFHandlingException when it has issues populating the extensions
@@ -45,12 +56,16 @@ public abstract class CommonEvent {
     public abstract void setExtension(Map<String, String> extensions, final boolean allowNulls) throws CEFHandlingException;
 
     /**
+     * Get map of named headers
+     *
      * @return A map containing the keys and values of headers
      * @throws CEFHandlingException when it has issues reading the headers of CEF event
      */
     public abstract Map<String, Object> getHeader() throws CEFHandlingException;
 
     /**
+     * Get map of named extensions
+     *
      * @param populatedOnly Boolean defining if Map should include all fields supported by the <b>supported</b> CEF standard
      * @return A map containing the keys and values of CEF extensions
      * @throws CEFHandlingException when it hits issues (e.g. IllegalAccessException) reading the extensions
@@ -59,6 +74,8 @@ public abstract class CommonEvent {
 
 
     /**
+     * Get map of named extensions after applying specified filtering
+     *
      * @param populatedOnly Boolean defining if Map should include all fields supported by {@link com.fluenda.parcefone.event.CefRev23}
      * @param includeCustomExtensions Boolean defining if Map should include parsed keys that are not supported part of the base CEF Rev23 specification
      * @return A map containing the keys and values of CEF extensions

--- a/src/main/java/com/fluenda/parcefone/parser/CEFParser.java
+++ b/src/main/java/com/fluenda/parcefone/parser/CEFParser.java
@@ -21,10 +21,10 @@ import com.fluenda.parcefone.event.CEFHandlingException;
 import com.fluenda.parcefone.event.CefRev23;
 import com.fluenda.parcefone.event.CommonEvent;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import java.nio.charset.Charset;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -64,27 +64,33 @@ public class CEFParser {
     }
 
     /**
+     * Parse byte array after converting to UTF-8 string with validation disabled
+     *
      * @return CommonEvent
      * @param cefByteArray byte [] containing the CEF message to be parsed - Array will be converted String using UTF-8
      */
     public CommonEvent parse(byte [] cefByteArray)  {
         String cefString;
-        cefString = new String(cefByteArray, Charset.forName("UTF-8"));
+        cefString = new String(cefByteArray, StandardCharsets.UTF_8);
         return this.parse(cefString, false);
     }
 
     /**
+     * Parse byte array after converting to UTF-8 string with validation enabled or disabled
+     *
      * @return CommonEvent
      * @param cefByteArray byte [] containing the CEF message to be parsed - Array will be converted String using UTF-8
      * @param validate Boolean if parser should validate values beyond type compatibility (e.g. Values within acceptable lengths, value lists, etc)
      */
     public CommonEvent parse(byte [] cefByteArray, boolean validate)  {
         String cefString;
-        cefString = new String(cefByteArray, Charset.forName("UTF-8"));
+        cefString = new String(cefByteArray, StandardCharsets.UTF_8);
         return this.parse(cefString, validate);
     }
 
     /**
+     * Parse byte array after converting to UTF-8 string using specified Locale and with validation enabled or disabled
+     *
      * @return CommonEvent
      * @param cefByteArray byte [] containing the CEF message to be parsed - Array will be converted String using UTF-8
      * @param validate Boolean if parser should validate values beyond type compatibility (e.g. Values within acceptable lengths, value lists, etc)
@@ -92,11 +98,13 @@ public class CEFParser {
      */
     public CommonEvent parse(byte [] cefByteArray, boolean validate, Locale locale)  {
         String cefString;
-        cefString = new String(cefByteArray, Charset.forName("UTF-8"));
+        cefString = new String(cefByteArray, StandardCharsets.UTF_8);
         return this.parse(cefString, validate, locale);
     }
 
     /**
+     * Parse byte array after converting to UTF-8 string using specified Locale and with validation and allow nulsl enabled or disabled
+     *
      * @return CommonEvent
      * @param cefByteArray byte [] containing the CEF message to be parsed - Array will be converted String using UTF-8
      * @param validate Boolean if parser should validate values beyond type compatibility (e.g. Values within acceptable lengths, value lists, etc)
@@ -105,7 +113,7 @@ public class CEFParser {
      */
     public CommonEvent parse(byte [] cefByteArray, boolean validate, final boolean allowNulls, Locale locale)  {
         String cefString;
-        cefString = new String(cefByteArray, Charset.forName("UTF-8"));
+        cefString = new String(cefByteArray, StandardCharsets.UTF_8);
         return this.parse(cefString, validate, allowNulls, locale);
     }
 
@@ -174,7 +182,7 @@ public class CEFParser {
             return null;
         }
 
-        final HashMap<String, Object> headers = new HashMap<String, Object>();
+        final HashMap<String, Object> headers = new HashMap<>();
         headers.put("version", Integer.valueOf(extractedMessage[0].substring(extractedMessage[0].length() - 1)));
         headers.put("deviceVendor", extractedMessage[1]);
         headers.put("deviceProduct", extractedMessage[2]);
@@ -183,7 +191,7 @@ public class CEFParser {
         headers.put("name", extractedMessage[5]);
         headers.put("severity", extractedMessage[6]);
 
-        final HashMap<String, String> extensions = new HashMap<String, String>();
+        final HashMap<String, String> extensions = new HashMap<>();
 
 
         final String ext = extractedMessage[7];
@@ -242,12 +250,12 @@ public class CEFParser {
         if (validate) {
             if (validator == null) {
                 // Since the validator wasn't initiated previously, create a new one;
-                this.validator = Validation.buildDefaultValidatorFactory().getValidator();;
+                this.validator = Validation.buildDefaultValidatorFactory().getValidator();
             }
 
             Set<ConstraintViolation<CommonEvent>> validationResult = validator.validate(cefEvent);
 
-            if (validationResult.size() > 0) {
+            if (!validationResult.isEmpty()) {
                 if (logger.isDebugEnabled()) {
                     for(ConstraintViolation<CommonEvent> v : validationResult) {
                         logger.debug("CEF message failed validation: " + v.getMessage());

--- a/src/test/java/com/fluenda/parcefone/event/MacAddressTest.java
+++ b/src/test/java/com/fluenda/parcefone/event/MacAddressTest.java
@@ -16,15 +16,14 @@
  */
 package com.fluenda.parcefone.event;
 
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MacAddressTest {
 
@@ -84,12 +83,7 @@ public class MacAddressTest {
 
     @Test
     public void testAddressInvalidLength() {
-        assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
-            @Override
-            public void run() {
-                new MacAddress(INVALID_LENGTH);
-            }
-        });
+        assertThrows(IllegalArgumentException.class, () -> new MacAddress(INVALID_LENGTH));
     }
 
     @Test

--- a/src/test/java/com/fluenda/parcefone/parser/CEFParserTest.java
+++ b/src/test/java/com/fluenda/parcefone/parser/CEFParserTest.java
@@ -18,19 +18,23 @@ package com.fluenda.parcefone.parser;
 
 import com.fluenda.parcefone.event.CommonEvent;
 import com.fluenda.parcefone.event.MacAddress;
-import com.fluenda.parcefone.parser.CEFParser;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import javax.validation.Validation;
-import javax.validation.Validator;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import java.net.InetAddress;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CEFParserTest {
 
@@ -44,9 +48,9 @@ public class CEFParserTest {
         result = parser.parse(arcsightSample1, true);
         Map<String, Object> resultMap = result.getExtension(true, true);
         int modelConfidence = Integer.valueOf((String) resultMap.get("modelConfidence"));
-        Assert.assertEquals("Custom Extension modelConfidence 0", 0, modelConfidence);
+        assertEquals(0, modelConfidence, "Custom Extension modelConfidence 0");
         InetAddress inetAddress = (InetAddress) resultMap.get("c6a3");
-        Assert.assertEquals("Mapped IPV4 in IPV6 field: 10.142.108.195", "/10.142.108.195", inetAddress.toString());
+        assertEquals("/10.142.108.195", inetAddress.toString(), "Mapped IPV4 in IPV6 field: 10.142.108.195");
     }
 
     @Test
@@ -85,39 +89,39 @@ public class CEFParserTest {
 
         // Test sample1
         result = parser.parse(sample1, true);
-        Assert.assertNotNull(result);
-        Assert.assertEquals("TestVendor" , result.getHeader().get("deviceVendor"));
-        Assert.assertEquals(new Date(1423441663000L), result.getExtension(true).get("rt"));
-        Assert.assertEquals("Test Long", result.getExtension(true).get("cn3Label"));
-        Assert.assertEquals(9223372036854775807L, result.getExtension(true).get("cn3"));
-        Assert.assertEquals(1.234F, result.getExtension(true).get("cfp1"));
-        Assert.assertEquals("Test FP Number", result.getExtension(true).get("cfp1Label"));
-        Assert.assertEquals(new MacAddress("00.00.0c.07.ac.00"), result.getExtension(true).get("smac"));
-        Assert.assertEquals(InetAddress.getByName("2001:cdba:0000:0000:0000:0000:3257:9652"), result.getExtension(true).get("c6a3"));
-        Assert.assertEquals("Test IPv6", result.getExtension(true).get("c6a3Label"));
-        Assert.assertEquals(InetAddress.getByName("123.123.123.123"), result.getExtension(true).get("destinationTranslatedAddress"));
-        Assert.assertEquals(new SimpleDateFormat("MMM dd yyyy HH:mm:ss").parse("Feb 09 2015 00:27:43"), result.getExtension(true).get("deviceCustomDate1"));
-        Assert.assertEquals(1234, result.getExtension(true).get("dpt"));
-        Assert.assertEquals(InetAddress.getByName("123.123.0.124"), result.getExtension(true).get("agt"));
-        Assert.assertEquals(40.366633D, result.getExtension(true).get("dlat"));
+        assertNotNull(result);
+        assertEquals("TestVendor" , result.getHeader().get("deviceVendor"));
+        assertEquals(new Date(1423441663000L), result.getExtension(true).get("rt"));
+        assertEquals("Test Long", result.getExtension(true).get("cn3Label"));
+        assertEquals(9223372036854775807L, result.getExtension(true).get("cn3"));
+        assertEquals(1.234F, result.getExtension(true).get("cfp1"));
+        assertEquals("Test FP Number", result.getExtension(true).get("cfp1Label"));
+        assertEquals(new MacAddress("00.00.0c.07.ac.00"), result.getExtension(true).get("smac"));
+        assertEquals(InetAddress.getByName("2001:cdba:0000:0000:0000:0000:3257:9652"), result.getExtension(true).get("c6a3"));
+        assertEquals("Test IPv6", result.getExtension(true).get("c6a3Label"));
+        assertEquals(InetAddress.getByName("123.123.123.123"), result.getExtension(true).get("destinationTranslatedAddress"));
+        assertEquals(new SimpleDateFormat("MMM dd yyyy HH:mm:ss").parse("Feb 09 2015 00:27:43"), result.getExtension(true).get("deviceCustomDate1"));
+        assertEquals(1234, result.getExtension(true).get("dpt"));
+        assertEquals(InetAddress.getByName("123.123.0.124"), result.getExtension(true).get("agt"));
+        assertEquals(40.366633D, result.getExtension(true).get("dlat"));
 
         // Test sample2
         result = parser.parse(sample2, true);
-        Assert.assertNotNull(result);
-        Assert.assertEquals("TestVendor" , result.getHeader().get("deviceVendor"));
-        Assert.assertEquals(new Date(1423441663000L), result.getExtension(true).get("rt"));
-        Assert.assertEquals("Test Long", result.getExtension(true).get("cn3Label"));
-        Assert.assertEquals(9223372036854775807L, result.getExtension(true).get("cn3"));
-        Assert.assertEquals(1.234F, result.getExtension(true).get("cfp1"));
-        Assert.assertEquals("Test FP Number", result.getExtension(true).get("cfp1Label"));
-        Assert.assertEquals(new MacAddress("00.00.0c.07.ac.00"), result.getExtension(true).get("smac"));
-        Assert.assertEquals(InetAddress.getByName("2001:cdba:0:0:0:0:3257:9652"), result.getExtension(true).get("c6a3"));
-        Assert.assertEquals("Test IPv6", result.getExtension(true).get("c6a3Label"));
-        Assert.assertEquals(InetAddress.getByName("123.123.123.123"), result.getExtension(true).get("destinationTranslatedAddress"));
-        Assert.assertEquals(new SimpleDateFormat("MMM dd yyyy HH:mm:ss").parse("Feb 09 2015 00:27:43"), result.getExtension(true).get("deviceCustomDate1"));
-        Assert.assertEquals(1234, result.getExtension(true).get("dpt"));
-        Assert.assertEquals(InetAddress.getByName("2001:cdba::3257:9652"), result.getExtension(true).get("agt"));
-        Assert.assertEquals(40.366633D, result.getExtension(true).get("dlat"));
+        assertNotNull(result);
+        assertEquals("TestVendor" , result.getHeader().get("deviceVendor"));
+        assertEquals(new Date(1423441663000L), result.getExtension(true).get("rt"));
+        assertEquals("Test Long", result.getExtension(true).get("cn3Label"));
+        assertEquals(9223372036854775807L, result.getExtension(true).get("cn3"));
+        assertEquals(1.234F, result.getExtension(true).get("cfp1"));
+        assertEquals("Test FP Number", result.getExtension(true).get("cfp1Label"));
+        assertEquals(new MacAddress("00.00.0c.07.ac.00"), result.getExtension(true).get("smac"));
+        assertEquals(InetAddress.getByName("2001:cdba:0:0:0:0:3257:9652"), result.getExtension(true).get("c6a3"));
+        assertEquals("Test IPv6", result.getExtension(true).get("c6a3Label"));
+        assertEquals(InetAddress.getByName("123.123.123.123"), result.getExtension(true).get("destinationTranslatedAddress"));
+        assertEquals(new SimpleDateFormat("MMM dd yyyy HH:mm:ss").parse("Feb 09 2015 00:27:43"), result.getExtension(true).get("deviceCustomDate1"));
+        assertEquals(1234, result.getExtension(true).get("dpt"));
+        assertEquals(InetAddress.getByName("2001:cdba::3257:9652"), result.getExtension(true).get("agt"));
+        assertEquals(40.366633D, result.getExtension(true).get("dlat"));
     }
 
     @Test
@@ -126,10 +130,10 @@ public class CEFParserTest {
         CEFParser parser = new CEFParser();
 
         // Test sample
-        Assert.assertNotNull(parser.parse(sample1));
-        Assert.assertTrue(parser.parse(sample1).getHeader().containsKey("deviceVendor"));
-        Assert.assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1).getExtension(true).get("dvc"));
-        Assert.assertNull(parser.parse(sample1).getExtension(true).get("act"));
+        assertNotNull(parser.parse(sample1));
+        assertTrue(parser.parse(sample1).getHeader().containsKey("deviceVendor"));
+        assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1).getExtension(true).get("dvc"));
+        assertNull(parser.parse(sample1).getExtension(true).get("act"));
     }
 
     @Test
@@ -142,12 +146,12 @@ public class CEFParserTest {
         CommonEvent result = parser.parse(sample1, false, true, Locale.ENGLISH);
 
         // Test sample
-        Assert.assertNotNull(result);
-        Assert.assertTrue(result.getHeader().containsKey("deviceVendor"));
-        Assert.assertFalse(result.getExtension(true).containsKey("act"));
-        Assert.assertTrue(result.getExtension(true).containsKey("cn3") && result.getExtension(true).get("cn3") == null);
-        Assert.assertTrue(result.getExtension(true).containsKey("dvc") && result.getExtension(true).get("dvc") == null);
-        Assert.assertTrue(result.getExtension(true).containsKey("smac") && result.getExtension(true).get("smac") == null);
+        assertNotNull(result);
+        assertTrue(result.getHeader().containsKey("deviceVendor"));
+        assertFalse(result.getExtension(true).containsKey("act"));
+        assertTrue(result.getExtension(true).containsKey("cn3") && result.getExtension(true).get("cn3") == null);
+        assertTrue(result.getExtension(true).containsKey("dvc") && result.getExtension(true).get("dvc") == null);
+        assertTrue(result.getExtension(true).containsKey("smac") && result.getExtension(true).get("smac") == null);
     }
 
     @Test
@@ -158,10 +162,10 @@ public class CEFParserTest {
         byte[] sample1Array = sample1.getBytes(Charset.forName("UTF-8"));
 
         // Test sample
-        Assert.assertNotNull(parser.parse(sample1Array));
-        Assert.assertTrue(parser.parse(sample1Array).getHeader().containsKey("deviceVendor"));
-        Assert.assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1Array).getExtension(true).get("dvc"));
-        Assert.assertNull(parser.parse(sample1Array).getExtension(true).get("act"));
+        assertNotNull(parser.parse(sample1Array));
+        assertTrue(parser.parse(sample1Array).getHeader().containsKey("deviceVendor"));
+        assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1Array).getExtension(true).get("dvc"));
+        assertNull(parser.parse(sample1Array).getExtension(true).get("act"));
     }
 
     @Test
@@ -172,10 +176,10 @@ public class CEFParserTest {
         byte[] sample1Array = sample1.getBytes(Charset.forName("UTF-8"));
 
         // Test sample
-        Assert.assertNotNull(parser.parse(sample1Array, true));
-        Assert.assertTrue(parser.parse(sample1Array, true).getHeader().containsKey("deviceVendor"));
-        Assert.assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1Array, true).getExtension(true).get("dvc"));
-        Assert.assertNull(parser.parse(sample1Array, true).getExtension(true).get("act"));
+        assertNotNull(parser.parse(sample1Array, true));
+        assertTrue(parser.parse(sample1Array, true).getHeader().containsKey("deviceVendor"));
+        assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1Array, true).getExtension(true).get("dvc"));
+        assertNull(parser.parse(sample1Array, true).getExtension(true).get("act"));
     }
 
     @Test
@@ -186,11 +190,11 @@ public class CEFParserTest {
         byte[] sample1Array = sample1.getBytes(Charset.forName("UTF-8"));
 
         // Test sample
-        Assert.assertNotNull(parser.parse(sample1Array, true, Locale.FRANCE));
-        Assert.assertTrue(parser.parse(sample1Array, true, Locale.FRANCE).getHeader().containsKey("deviceVendor"));
-        Assert.assertEquals(new Date(1436401663000L), parser.parse(sample1Array, true, Locale.FRANCE).getExtension(true).get("rt"));
-        Assert.assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1Array, true, Locale.FRANCE).getExtension(true).get("dvc"));
-        Assert.assertNull(parser.parse(sample1Array, true, Locale.FRANCE).getExtension(true).get("act"));
+        assertNotNull(parser.parse(sample1Array, true, Locale.FRANCE));
+        assertTrue(parser.parse(sample1Array, true, Locale.FRANCE).getHeader().containsKey("deviceVendor"));
+        assertEquals(new Date(1436401663000L), parser.parse(sample1Array, true, Locale.FRANCE).getExtension(true).get("rt"));
+        assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1Array, true, Locale.FRANCE).getExtension(true).get("dvc"));
+        assertNull(parser.parse(sample1Array, true, Locale.FRANCE).getExtension(true).get("act"));
     }
 
     @Test
@@ -199,11 +203,11 @@ public class CEFParserTest {
         CEFParser parser = new CEFParser();
 
         // Test sample
-        Assert.assertNotNull(parser.parse(sample1, true, Locale.FRANCE));
-        Assert.assertTrue(parser.parse(sample1, true, Locale.FRANCE).getHeader().containsKey("deviceVendor"));
-        Assert.assertEquals(new Date(1436401663000L), parser.parse(sample1, true, Locale.FRANCE).getExtension(true).get("rt"));
-        Assert.assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1, true, Locale.FRANCE).getExtension(true).get("dvc"));
-        Assert.assertNull(parser.parse(sample1, true, Locale.FRANCE).getExtension(true).get("act"));
+        assertNotNull(parser.parse(sample1, true, Locale.FRANCE));
+        assertTrue(parser.parse(sample1, true, Locale.FRANCE).getHeader().containsKey("deviceVendor"));
+        assertEquals(new Date(1436401663000L), parser.parse(sample1, true, Locale.FRANCE).getExtension(true).get("rt"));
+        assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1, true, Locale.FRANCE).getExtension(true).get("dvc"));
+        assertNull(parser.parse(sample1, true, Locale.FRANCE).getExtension(true).get("act"));
     }
 
     @Test
@@ -212,11 +216,11 @@ public class CEFParserTest {
         CEFParser parser = new CEFParser();
 
         // Test sample
-        Assert.assertNotNull(parser.parse(sample1, true, Locale.FRANCE));
-        Assert.assertTrue(parser.parse(sample1, true, Locale.FRANCE).getHeader().containsKey("deviceVendor"));
-        Assert.assertEquals(new SimpleDateFormat("MMM dd yyyy HH:mm:ss").parse("Jul 09 2015 00:27:43"), parser.parse(sample1, true, Locale.FRANCE).getExtension(true).get("rt"));
-        Assert.assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1, true, Locale.FRANCE).getExtension(true).get("dvc"));
-        Assert.assertNull(parser.parse(sample1, true, Locale.FRANCE).getExtension(true).get("act"));
+        assertNotNull(parser.parse(sample1, true, Locale.FRANCE));
+        assertTrue(parser.parse(sample1, true, Locale.FRANCE).getHeader().containsKey("deviceVendor"));
+        assertEquals(new SimpleDateFormat("MMM dd yyyy HH:mm:ss").parse("Jul 09 2015 00:27:43"), parser.parse(sample1, true, Locale.FRANCE).getExtension(true).get("rt"));
+        assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1, true, Locale.FRANCE).getExtension(true).get("dvc"));
+        assertNull(parser.parse(sample1, true, Locale.FRANCE).getExtension(true).get("act"));
     }
 
     @Test
@@ -233,47 +237,47 @@ public class CEFParserTest {
 
         // Test 1st sample
         CommonEvent result = parser.parse(sample1, true);
-        Assert.assertNotNull(result);
-        Assert.assertTrue(result.getHeader().containsKey("deviceVendor"));
-        Assert.assertEquals(InetAddress.getByName("10.100.25.16"), result.getExtension(true).get("dvc"));
-        Assert.assertEquals(new Date(1423441663000L), result.getExtension(true).get("rt"));
-        Assert.assertEquals(Long.valueOf("80494706"), result.getExtension(true).get("cn2"));
-        Assert.assertEquals(Integer.valueOf("61395"), result.getExtension(true).get("spt"));
-        Assert.assertEquals("udp", result.getExtension(true).get("proto"));
-        Assert.assertFalse(result.getExtension(true).containsKey("act"));
+        assertNotNull(result);
+        assertTrue(result.getHeader().containsKey("deviceVendor"));
+        assertEquals(InetAddress.getByName("10.100.25.16"), result.getExtension(true).get("dvc"));
+        assertEquals(new Date(1423441663000L), result.getExtension(true).get("rt"));
+        assertEquals(Long.valueOf("80494706"), result.getExtension(true).get("cn2"));
+        assertEquals(Integer.valueOf("61395"), result.getExtension(true).get("spt"));
+        assertEquals("udp", result.getExtension(true).get("proto"));
+        assertFalse(result.getExtension(true).containsKey("act"));
 
         // Test 2nd sample
         result = parser.parse(sample2, true);
-        Assert.assertNotNull(result);
-        Assert.assertTrue(result.getHeader().containsKey("deviceVendor"));
-        Assert.assertFalse(result.getExtension(true).containsKey("dvc"));
+        assertNotNull(result);
+        assertTrue(result.getHeader().containsKey("deviceVendor"));
+        assertFalse(result.getExtension(true).containsKey("dvc"));
 
         // Test 3rd sample
         result = parser.parse(sample3, true);
-        Assert.assertNotNull(result);
-        Assert.assertTrue(result.getHeader().containsKey("deviceVendor"));
-        Assert.assertEquals(InetAddress.getByName("1.1.1.1"),result.getExtension(true).get("dst"));
-        Assert.assertEquals(InetAddress.getByName("10.0.0.1"),result.getExtension(true).get("src"));
-        Assert.assertEquals("blocked a |",result.getExtension(true).get("act"));
+        assertNotNull(result);
+        assertTrue(result.getHeader().containsKey("deviceVendor"));
+        assertEquals(InetAddress.getByName("1.1.1.1"),result.getExtension(true).get("dst"));
+        assertEquals(InetAddress.getByName("10.0.0.1"),result.getExtension(true).get("src"));
+        assertEquals("blocked a |",result.getExtension(true).get("act"));
 
         // Test 4th sample
         result = parser.parse(sample4, true);
-        Assert.assertNotNull(result);
-        Assert.assertTrue(result.getHeader().containsKey("deviceVendor"));
-        Assert.assertEquals(InetAddress.getByName("1.1.1.1"), result.getExtension(true).get("dst"));
-        Assert.assertEquals(InetAddress.getByName("10.0.0.1"), result.getExtension(true).get("src"));
-        Assert.assertEquals("blocked a \\\\", result.getExtension(true).get("act"));
+        assertNotNull(result);
+        assertTrue(result.getHeader().containsKey("deviceVendor"));
+        assertEquals(InetAddress.getByName("1.1.1.1"), result.getExtension(true).get("dst"));
+        assertEquals(InetAddress.getByName("10.0.0.1"), result.getExtension(true).get("src"));
+        assertEquals("blocked a \\\\", result.getExtension(true).get("act"));
 
         // Test 5th sample
         result = parser.parse(sample5, true);
-        Assert.assertNotNull(result);
-        Assert.assertTrue(result.getHeader().containsKey("deviceVendor"));
+        assertNotNull(result);
+        assertTrue(result.getHeader().containsKey("deviceVendor"));
         // Test leading space on first KV pair
-        Assert.assertEquals(1032L, result.getExtension(true).get("eventId"));
-        Assert.assertEquals(InetAddress.getByName("10.128.10.42"), result.getExtension(true).get("dst"));
-        Assert.assertEquals(InetAddress.getByName("72.238.189.126"), result.getExtension(true).get("src"));
-        Assert.assertEquals("/All Zones/ArcSight System/Private Address Space Zones/RFC1918: 10.0.0.0-10.255.255.255", result.getExtension(true).get("deviceZoneURI"));
-        Assert.assertEquals(new Date(1396032820000L), result.getExtension(true).get("rt"));
+        assertEquals(1032L, result.getExtension(true).get("eventId"));
+        assertEquals(InetAddress.getByName("10.128.10.42"), result.getExtension(true).get("dst"));
+        assertEquals(InetAddress.getByName("72.238.189.126"), result.getExtension(true).get("src"));
+        assertEquals("/All Zones/ArcSight System/Private Address Space Zones/RFC1918: 10.0.0.0-10.255.255.255", result.getExtension(true).get("deviceZoneURI"));
+        assertEquals(new Date(1396032820000L), result.getExtension(true).get("rt"));
    }
 
 
@@ -283,11 +287,11 @@ public class CEFParserTest {
         CEFParser parser = new CEFParser();
 
         // Test 1st sample
-        Assert.assertNotNull(parser.parse(sample1, true));
-        Assert.assertTrue(parser.parse(sample1).getHeader().containsKey("deviceVendor"));
-        Assert.assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1).getExtension(true).get("dvc"));
-        Assert.assertTrue(parser.parse(sample1).getExtension(false).containsKey("act"));
-        Assert.assertNull(parser.parse(sample1).getExtension(false).get("act"));
+        assertNotNull(parser.parse(sample1, true));
+        assertTrue(parser.parse(sample1).getHeader().containsKey("deviceVendor"));
+        assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1).getExtension(true).get("dvc"));
+        assertTrue(parser.parse(sample1).getExtension(false).containsKey("act"));
+        assertNull(parser.parse(sample1).getExtension(false).get("act"));
     }
 
     @Test
@@ -297,11 +301,11 @@ public class CEFParserTest {
         CEFParser parser = new CEFParser();
 
         CommonEvent event = parser.parse(sample1, true);
-        Assert.assertNull(event);
+        assertNull(event);
 
         String sample2 = "CEF:0|security|threatmanager|1.0|100|detected a \\\\ in packet|10|src=10.0.0.1 proto=xdp dst=1.1.1.1";
         event = parser.parse(sample2, true);
-        Assert.assertNull(event);
+        assertNull(event);
     }
 
     @Test
@@ -311,7 +315,7 @@ public class CEFParserTest {
         CEFParser parser = new CEFParser();
 
         CommonEvent event = parser.parse(sample1, true);
-        Assert.assertNull(event);
+        assertNull(event);
 
     }
 
@@ -322,9 +326,9 @@ public class CEFParserTest {
         CEFParser parser = new CEFParser();
 
         CommonEvent event = parser.parse(sample1, true);
-        Assert.assertNotNull(event);
-        Assert.assertTrue(event.getHeader().containsKey("deviceVendor"));
-        Assert.assertEquals("", event.getHeader().get("deviceVendor"));
+        assertNotNull(event);
+        assertTrue(event.getHeader().containsKey("deviceVendor"));
+        assertEquals("", event.getHeader().get("deviceVendor"));
     }
 
     @Test
@@ -334,7 +338,7 @@ public class CEFParserTest {
         CEFParser parser = new CEFParser();
 
         CommonEvent event = parser.parse(sample1, true);
-        Assert.assertNull(event);
+        assertNull(event);
     }
 
     @Test
@@ -347,10 +351,10 @@ public class CEFParserTest {
         CEFParser parser = new CEFParser(validator);
 
         // Test 1st sample
-        Assert.assertNotNull(parser.parse(sample1, true));
-        Assert.assertTrue(parser.parse(sample1).getHeader().containsKey("deviceVendor"));
-        Assert.assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1).getExtension(true).get("dvc"));
-        Assert.assertTrue(parser.parse(sample1).getExtension(false).containsKey("act"));
-        Assert.assertNull(parser.parse(sample1).getExtension(false).get("act"));
+        assertNotNull(parser.parse(sample1, true));
+        assertTrue(parser.parse(sample1).getHeader().containsKey("deviceVendor"));
+        assertEquals(InetAddress.getByName("10.100.25.16"), parser.parse(sample1).getExtension(true).get("dvc"));
+        assertTrue(parser.parse(sample1).getExtension(false).containsKey("act"));
+        assertNull(parser.parse(sample1).getExtension(false).get("act"));
     }
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,8 +1,0 @@
-#  Logging level
-solr.log=logs/
-log4j.rootLogger=INFO, CONSOLE
-
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%-4r [%t] %-5p %c %x \u2013 %m%n


### PR DESCRIPTION
This pull request upgrades all project dependencies to the latest versions, aligning with the requirements of [Jakarta EE 10](https://jakarta.ee/release/10/).

These upgrades should be considered a breaking change for the project version.

Jakarta EE 10 includes the Jakarta Validation API version 3, which is the primary motivation for upgrading dependencies. Jakarta EE 10 also requires Java 11 as the minimum version, so this pull request updates plugins and workflows to build with Java 11.

Additional changes include adding JavaDoc comments in several places to resolve JavaDoc plugin warnings.

These upgrades also align with Jakarta EE 10 support for Apache NiFi 2.0.

Here is the complete list of upgraded dependencies and plugins:

- Upgraded Validation API from 1.1.0 to 3.0.2
- Upgraded SLF4J from 1.7.30 to 2.0.9
- Upgraded JUnit from 4.13.1 to 5.10.1
- Upgraded Hibernate Validator from 5.4.3 to 8.0.1
- Upgraded Expression Language from 3.0.1 to 5.0.0-M1
- Upgraded Maven JAR Plugin from 2.3.2 to 3.3.0
- Upgraded Maven Source Plugin from 2.1.2 to 3.3.0
- Upgraded Maven JavaDoc Plugin from 2.10.4 to 3.6.3
- Upgraded Maven Compiler Plugin from 3.8.1 to 3.12.1
- Upgraded Maven Checkstyle Plugin from 3.1.2 to 3.3.1
- Upgraded Maven GPG Plugin from 3.0.1 to 3.1.0
- Upgraded Apache Rat Plugin from 0.13 to 0.15